### PR TITLE
Fix: Make EchoServiceIntegrationTest robust by using direct gRPC channel

### DIFF
--- a/yappy-engine/src/test/resources/application-test-echo-grpc-working-standalone.yml
+++ b/yappy-engine/src/test/resources/application-test-echo-grpc-working-standalone.yml
@@ -14,7 +14,7 @@ grpc:
   client:
     plaintext: true
     discovery:
-      enabled: true
+      enabled: false
 
 
 # Consul client configuration
@@ -30,7 +30,7 @@ consul:
         interval: 5s
         timeout: 3s
     discovery:
-      enabled: true
+      enabled: false
     config:
       enabled: true
       format: properties


### PR DESCRIPTION
I modified EchoServiceIntegrationTest to manually create and manage its gRPC client channel. The client now connects directly to the EchoService instance running within the test's own Micronaut application context, using the embedded server's port.

This change enhances test isolation and prevents flakiness caused by interactions with a shared service discovery mechanism (Consul) when tests are run as part of a larger suite. The previous setup was prone to failures if Consul's state was affected by other tests.

Changes include:
- In EchoServiceIntegrationTest.java:
  - Removed injected gRPC stub.
  - Injected EmbeddedServer to obtain the gRPC port.
  - Added @BeforeEach and @AfterEach methods to manage the lifecycle of a direct ManagedChannel and client stub.
- In application-test-echo-grpc-working-standalone.yml:
  - Disabled consul.client.discovery.enabled and grpc.client.discovery.enabled as they are no longer needed by this test's client.
- Added Javadoc to EchoServiceIntegrationTest explaining the new setup.